### PR TITLE
default to not keeping the STAR index in shared memory

### DIFF
--- a/finder
+++ b/finder
@@ -256,6 +256,7 @@ def validateCommandLineArguments(options,logger_proxy,logging_mutex):
         cmd += f" --genomeFastaFiles {options.genome}"
         cmd += f" --genomeChrBinNbits {genomeChrBinNbits_value}"
         cmd += f" --genomeSAindexNbases {genomeSAindexNbases_value}"
+        cmd += f" --outFileNamePrefix {options.output_star}/indexGenome"
         cmd+=" > "+options.genome_dir_star+".output "
         cmd+=" 2> "+options.genome_dir_star+".error "
         if os.path.exists(f"{options.genome_dir_star}/SAindex")==False:
@@ -271,6 +272,7 @@ def validateCommandLineArguments(options,logger_proxy,logging_mutex):
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
 
     if options.genome_dir_olego is None:  

--- a/finder
+++ b/finder
@@ -104,6 +104,7 @@ def parseCommandLineArguments():
     optional_named.add_argument("--addUTR","--addUTR",help="Turn on this option if you wish BRAKER to add UTR sequences",action="store_true")
     optional_named.add_argument("--skip_cpd","--skip_cpd",help="Turn on this option to skip changepoint detection. Could be effective for grasses",action="store_true")
     optional_named.add_argument("--exonerate_gff3","-egff3",help="Enter the exonerate output in gff3 format")
+    optional_named.add_argument("--star_shared_mem","--star_shared_mem",help="Turn on this option if you want STAR to load the genome index into shared memory. This saves memory if multiple finder runs are executing on the same host, but might not work in your cluster environment.",action="store_true")
     #optional_named.add_argument("--intron_gff3","-intron_gff3",help="Enter the name and location of the file containing introns in gff3 format")
     #optional_named.add_argument("--ground_truth_gtf","-gt_gtf",help="Enter the gtf filename of the actual annotation [for developmental purposes]")
     #optional_named.add_argument("--error_correct_reads","-ecr",help="Set this argument if you wish to perform error corrections using Rcorrector. Please note that setting this option does not guarantee correction. Short read error correction is a time consuming task. Hence, only those samples will be error corrected which have a low mapping rate. Please refer to page no. <> of the manual for more details. ",action="store_true")
@@ -249,6 +250,8 @@ def validateCommandLineArguments(options,logger_proxy,logging_mutex):
         cmd  = f"STAR "
         cmd += f" --runThreadN {options.cpu}"
         cmd += f" --runMode genomeGenerate "
+        if options.star_shared_mem == True:
+            cmd += f" --genomeLoad LoadAndKeep"
         cmd += f" --genomeDir {options.genome_dir_star}"
         cmd += f" --genomeFastaFiles {options.genome}"
         cmd += f" --genomeChrBinNbits {genomeChrBinNbits_value}"
@@ -262,13 +265,14 @@ def validateCommandLineArguments(options,logger_proxy,logging_mutex):
             with logging_mutex:
                 logger_proxy.info("STAR index generation complete")
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
-    
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
+
     if options.genome_dir_olego is None:  
         with logging_mutex:
             logger_proxy.info("Generating OLego index")

--- a/scripts/alignReads.py
+++ b/scripts/alignReads.py
@@ -23,7 +23,8 @@ def alignReadsWithSTARRound1(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=" --outSJfilterOverhangMin 12 12 12 12 "
     cmd+=" --outSAMattributes NH HI AS nM NM MD jM jI XS "
     cmd+=" --outReadsUnmapped Fastx "
-    cmd+=" --genomeLoad LoadAndKeep "
+    if options.star_shared_mem == True:
+        cmd+=" --genomeLoad LoadAndKeep "
     cmd+=" --outFileNamePrefix "+options.output_star+"/"+Run+"_round1_"
     cmd+=" --outSJfilterCountUniqueMin 1 1 1 1 "
     cmd+=" --outSJfilterCountTotalMin 1 1 1 1 "
@@ -44,12 +45,13 @@ def alignReadsWithSTARRound1(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=options.output_star+"/"+Run+"_round1_Log.out "
     os.system(cmd)
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
     
     with logging_mutex:
         logger_proxy.info("STAR Round1 run for "+Run+" completed")
@@ -86,7 +88,8 @@ def alignReadsWithSTARRelaxed(options,Run,ended,condition,logger_proxy,logging_m
     """
     
     """if Run_num!=0:
-        cmd+=" --genomeLoad LoadAndKeep "
+        if options.star_shared_mem == True:
+            cmd+=" --genomeLoad LoadAndKeep "
     """    
     cmd+=" --outFileNamePrefix "+options.output_star+"/"+Run+"_final_"
     cmd+=" --outSJfilterCountUniqueMin 1 1 1 1 " 
@@ -128,12 +131,14 @@ def alignReadsWithSTARRelaxed(options,Run,ended,condition,logger_proxy,logging_m
     cmd+=options.output_star+"/"+Run+"_round3_Log.final.out"
     os.system(cmd)
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
+
     with logging_mutex:
         logger_proxy.info("STAR relaxed alignment run for "+Run+" completed")
               
@@ -169,7 +174,8 @@ def alignReadsWithSTARRound2(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=" --sjdbFileChrStartEnd "+options.output_star+"/"+condition+"_round1_SJ.out.tab "
     
     """if Run_num!=0:
-        cmd+=" --genomeLoad LoadAndKeep "
+        if options.star_shared_mem == True:
+            cmd+=" --genomeLoad LoadAndKeep "
     """    
     cmd+=" --outFileNamePrefix "+options.output_star+"/"+Run+"_round2_"
     cmd+=" --outSJfilterCountUniqueMin 1 1 1 1 " 
@@ -188,12 +194,13 @@ def alignReadsWithSTARRound2(options,Run,ended,condition,logger_proxy,logging_mu
     #sys.stdout.flush()
     os.system(cmd)
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
     
     cmd="rm "
     cmd+=options.output_star+"/"+Run+"_round2_Log.progress.out "+options.output_star+"/"+Run+"_round2_Log.out"
@@ -234,7 +241,8 @@ def alignReadsWithSTARRound3(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=" --sjdbFileChrStartEnd "+options.output_star+"/"+condition+"_round2_SJ.out.tab "
     
     """if Run_num!=0:
-        cmd+=" --genomeLoad LoadAndKeep "
+        if options.star_shared_mem == True:
+            cmd+=" --genomeLoad LoadAndKeep "
     """    
     cmd+=" --outFileNamePrefix "+options.output_star+"/"+Run+"_round3_"
     cmd+=" --outSJfilterCountUniqueMin 1 1 1 1 " 
@@ -253,12 +261,13 @@ def alignReadsWithSTARRound3(options,Run,ended,condition,logger_proxy,logging_mu
     sys.stdout.flush()
     os.system(cmd)
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
     
     cmd="rm "
     cmd+=options.output_star+"/"+Run+"_round3_Log.progress.out "+options.output_star+"/"+Run+"_round3_Log.out"
@@ -286,7 +295,8 @@ def alignReadsWithSTARRound4(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=" --outSAMattributes NH HI AS nM NM MD jM jI XS "
     cmd+=" --outReadsUnmapped Fastx "
     cmd+=" --outSAMattrRGline ID:4 "
-    cmd+=" --genomeLoad LoadAndKeep "
+    if options.star_shared_mem == True:
+        cmd+=" --genomeLoad LoadAndKeep "
     cmd+=" --outFileNamePrefix "+options.output_star+"/"+Run+"_round4_"
     cmd+=" --outSJfilterCountUniqueMin 3 3 3 3 " # Stricter bounds than round1
     cmd+=" --outSJfilterCountTotalMin 5 5 5 5 " # Stricter bounds than round1
@@ -302,12 +312,13 @@ def alignReadsWithSTARRound4(options,Run,ended,condition,logger_proxy,logging_mu
     cmd+=" 2> "+options.output_star+"/"+Run+"_round4.error"
     os.system(cmd)
     
-    # Remove a pre-loaded genome
-    cmd  = "STAR "
-    cmd += f" --runThreadN {options.cpu} "
-    cmd += f" --genomeLoad Remove "
-    cmd += f" --genomeDir {options.genome_dir_star} "
-    os.system(cmd)
+    if options.star_shared_mem == True:
+        # Remove a pre-loaded genome
+        cmd  = "STAR "
+        cmd += f" --runThreadN {options.cpu} "
+        cmd += f" --genomeLoad Remove "
+        cmd += f" --genomeDir {options.genome_dir_star} "
+        os.system(cmd)
     
     cmd="rm "
     cmd+=options.output_star+"/"+Run+"_round4_Log.progress.out "+options.output_star+"/"+Run+"_round4_Log.out"

--- a/scripts/alignReads.py
+++ b/scripts/alignReads.py
@@ -51,6 +51,7 @@ def alignReadsWithSTARRound1(options,Run,ended,condition,logger_proxy,logging_mu
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
     
     with logging_mutex:
@@ -137,6 +138,7 @@ def alignReadsWithSTARRelaxed(options,Run,ended,condition,logger_proxy,logging_m
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
 
     with logging_mutex:
@@ -200,6 +202,7 @@ def alignReadsWithSTARRound2(options,Run,ended,condition,logger_proxy,logging_mu
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
     
     cmd="rm "
@@ -267,6 +270,7 @@ def alignReadsWithSTARRound3(options,Run,ended,condition,logger_proxy,logging_mu
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
     
     cmd="rm "
@@ -318,6 +322,7 @@ def alignReadsWithSTARRound4(options,Run,ended,condition,logger_proxy,logging_mu
         cmd += f" --runThreadN {options.cpu} "
         cmd += f" --genomeLoad Remove "
         cmd += f" --genomeDir {options.genome_dir_star} "
+        cmd += f" --outFileNamePrefix {options.output_star}/removeGenomeShmem_"
         os.system(cmd)
     
     cmd="rm "


### PR DESCRIPTION
Thank you for the hard work on Finder! I look forward to applying it to the annotation of non-model species. 

The primary motivation for this pull request is to make Finder play nice when running on HPC clusters by disabling STAR's shared memory genome index loading by default and adding a boolean to enable it.

The first issue is that some cluster environments (including my own) don't support STAR's shared memory loading:
https://github.com/alexdobin/STAR/issues/841
https://github.com/BosingerLab/BALDR/issues/11

The default for STAR's genomeLoad parameter is "NoSharedMemory". 

The second issue is that the multiple invocations of

```
        # Remove a pre-loaded genome
        cmd  = "STAR "
        cmd += f" --runThreadN {options.cpu} "
        cmd += f" --genomeLoad Remove "
        cmd += f" --genomeDir {options.genome_dir_star} "
        os.system(cmd)
```

in finder and alignReads.py, as well as the genomeGenerate call do not specify an --outFileNamePrefix. This causes STAR output files (Log.out, etc.) to be written to the working directory where finder was launched, which causes crashes when running multiple jobs simultaneously from the same directory. 

Instead, all output should be directed to the value of Finder's `-out_dir` parameter.

I've tested this PR on the example dataset with the new boolean enabled and disabled, and the resulting predictions are the same. 